### PR TITLE
Wrong slippage limit was displayed in trade details on Instant. Sell …

### DIFF
--- a/cypress/integration/instant/NewTrade.spec.ts
+++ b/cypress/integration/instant/NewTrade.spec.ts
@@ -30,7 +30,7 @@ describe('New trade', () => {
     trade.expectToReceive('555.00');
 
     TradeData.expectPriceOf(/(277\.50)/);
-    TradeData.expectSlippageLimit(/2\.5%/);
+    TradeData.expectSlippageLimit(/5\.0%/);
     TradeData.expectPriceImpact(/0\.89%/);
 
     makeScreenshots('instant-trade');
@@ -42,7 +42,7 @@ describe('New trade', () => {
     trade.expectToPay('1.145');
 
     TradeData.expectPriceOf(/(279\.37)/);
-    TradeData.expectSlippageLimit(/2\.5%/);
+    TradeData.expectSlippageLimit(/5\.0%/);
     TradeData.expectPriceImpact(/0\.22%/);
   });
 

--- a/src/blockchain/calls/instant.tsx
+++ b/src/blockchain/calls/instant.tsx
@@ -43,7 +43,7 @@ export const tradePayWithETHWithProxy: TransactionDef<InstantOrderData> = {
     context: NetworkConfig
   ) => {
     const fixedBuyAmount = kind === OfferType.sell ?
-      buyAmount.times(one.minus(slippageLimit)) :
+      fixBuyAmount(buyAmount, slippageLimit) :
       buyAmount;
 
     const method = kind === OfferType.sell ?
@@ -80,7 +80,7 @@ export const tradePayWithETHWithProxy: TransactionDef<InstantOrderData> = {
     value: amountToWei(
       kind === OfferType.sell ?
         sellAmount :
-        sellAmount.times(one.plus(one.plus(slippageLimit))),
+        fixSellAmount(sellAmount, slippageLimit),
       sellToken).toFixed(0)
   }),
   kind: TxMetaKind.tradePayWithETHWithProxy,

--- a/src/instant/views/NewTradeView.tsx
+++ b/src/instant/views/NewTradeView.tsx
@@ -85,6 +85,7 @@ export class NewTradeView extends React.Component<InstantFormState> {
       quotation,
       user,
       kind,
+      slippageLimit
     } = this.props;
 
     return (
@@ -136,7 +137,7 @@ export class NewTradeView extends React.Component<InstantFormState> {
               <TradeData label="Slippage Limit"
                          data-test-id="trade-slippage-limit"
                          tooltip={slippageLimitTooltip}
-                         value={<FormatPercent value={new BigNumber(2.5)} precision={1}/>}
+                         value={<FormatPercent value={new BigNumber(slippageLimit.times(100))} precision={1}/>}
                          style={{ marginBottom: '2px' }}
               />
               <TradeData label="Gas cost"


### PR DESCRIPTION
…amount was used twice in signing tx when buying with proxy on intant.