### PR TITLE
[VERSION BUMP] 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Eth2Dai",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
- Included actual slippage limit being displayed
- Using infura key in readonly mode