### PR TITLE
[VERSION BUMP: 2.3.1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Eth2Dai",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
Fix: Display message showing that the user is on unsupported network.
Fix: Display both connect to wallet warning and not enough orders to fill an instant order.