### PR TITLE
(OT-640) Handle TxStatus.Propagating status properly for Create Order…

### DIFF
--- a/src/exchange/offerMake/offerMake.ts
+++ b/src/exchange/offerMake/offerMake.ts
@@ -643,6 +643,12 @@ function prepareSubmit(calls$: Calls$): [
                   return of(formStageChange(FormStage.editing));
                 case TxStatus.WaitingForConfirmation:
                   return of({ kind: FormChangeKind.formResetChange });
+                // There is the case where the status stays in TxStats.Propagating
+                // which comes before the TxStatus.WaitingForConfirmation.
+                // Sometimes the TX is successful without
+                // going through TxStatus.WaitingForConfirmation.
+                case TxStatus.Propagating:
+                  return of({ kind: FormChangeKind.formStageChange });
                 default:
                   return of();
               }


### PR DESCRIPTION
… form. Sometimes the tx goes from Propogating to success right away and it doesn't pass waitingForConfirmation. In order not to make the form inactive we reset the stage at propagation level as well.